### PR TITLE
Enhancement (ci): Use only master pr and tag refs for ci pipeline

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,3 @@
-# For Generate-DockerImageVariants: For CalVer releases. Each push to 'release' branch is a time-based release.
 name-template: '$RESOLVED_VERSION  🌈'
 tag-template: '$RESOLVED_VERSION'
 categories:

--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
     - master
-    - release # For Generate-DockerImageVariants: For CalVer releases. Each push to 'release' branch is a time-based release.
+    tags:
+    - '**'
   pull_request:
     branches:
     - master
@@ -14,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VARIANT_TAG: 3.12-curl-git-jq-ssh
-      # VARIANT_TAG_WITH_REF: 3.12-curl-git-jq-ssh-${GITHUB_REF}
       VARIANT_BUILD_DIR: variants/3.12-curl-git-jq-ssh
     steps:
     - name: Checkout
@@ -60,11 +60,12 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get 'ref-name' from 'refs/heads/ref-name'
+        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+        # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # For Generate-DockerImageVariants: Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
@@ -74,14 +75,13 @@ jobs:
         # echo "::set-output name=REF::$REF"
         # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
         # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-
-        # For Generate-DockerImageVariants: Set step output(s)
         echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
         echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
         echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
         echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
 
     - name: Login to docker registry
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
       run: echo "${DOCKERHUB_REGISTRY_PASSWORD}" | docker login -u "${DOCKERHUB_REGISTRY_USER}" --password-stdin
       env:
         DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
@@ -118,9 +118,7 @@ jobs:
 
     - name: Build and push (release)
       id: docker_build_release
-      # For Generate-DockerImageVariants: For CalVer releases. Each push to 'release' branch is a time-based release.
-      # if: startsWith(github.ref, 'refs/tags/')
-      if: github.ref == 'refs/heads/release'
+      if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
@@ -145,7 +143,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VARIANT_TAG: 3.12-curl-mysqlclient-openssl
-      # VARIANT_TAG_WITH_REF: 3.12-curl-mysqlclient-openssl-${GITHUB_REF}
       VARIANT_BUILD_DIR: variants/3.12-curl-mysqlclient-openssl
     steps:
     - name: Checkout
@@ -191,11 +188,12 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get 'ref-name' from 'refs/heads/ref-name'
+        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+        # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # For Generate-DockerImageVariants: Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
@@ -205,14 +203,13 @@ jobs:
         # echo "::set-output name=REF::$REF"
         # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
         # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-
-        # For Generate-DockerImageVariants: Set step output(s)
         echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
         echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
         echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
         echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
 
     - name: Login to docker registry
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
       run: echo "${DOCKERHUB_REGISTRY_PASSWORD}" | docker login -u "${DOCKERHUB_REGISTRY_USER}" --password-stdin
       env:
         DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
@@ -249,9 +246,7 @@ jobs:
 
     - name: Build and push (release)
       id: docker_build_release
-      # For Generate-DockerImageVariants: For CalVer releases. Each push to 'release' branch is a time-based release.
-      # if: startsWith(github.ref, 'refs/tags/')
-      if: github.ref == 'refs/heads/release'
+      if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
@@ -275,7 +270,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VARIANT_TAG: 3.11-curl-git-jq-ssh
-      # VARIANT_TAG_WITH_REF: 3.11-curl-git-jq-ssh-${GITHUB_REF}
       VARIANT_BUILD_DIR: variants/3.11-curl-git-jq-ssh
     steps:
     - name: Checkout
@@ -321,11 +315,12 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get 'ref-name' from 'refs/heads/ref-name'
+        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+        # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # For Generate-DockerImageVariants: Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
@@ -335,14 +330,13 @@ jobs:
         # echo "::set-output name=REF::$REF"
         # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
         # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-
-        # For Generate-DockerImageVariants: Set step output(s)
         echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
         echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
         echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
         echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
 
     - name: Login to docker registry
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
       run: echo "${DOCKERHUB_REGISTRY_PASSWORD}" | docker login -u "${DOCKERHUB_REGISTRY_USER}" --password-stdin
       env:
         DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
@@ -379,9 +373,7 @@ jobs:
 
     - name: Build and push (release)
       id: docker_build_release
-      # For Generate-DockerImageVariants: For CalVer releases. Each push to 'release' branch is a time-based release.
-      # if: startsWith(github.ref, 'refs/tags/')
-      if: github.ref == 'refs/heads/release'
+      if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
@@ -405,7 +397,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VARIANT_TAG: 3.11-curl-mysqlclient-openssl
-      # VARIANT_TAG_WITH_REF: 3.11-curl-mysqlclient-openssl-${GITHUB_REF}
       VARIANT_BUILD_DIR: variants/3.11-curl-mysqlclient-openssl
     steps:
     - name: Checkout
@@ -451,11 +442,12 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get 'ref-name' from 'refs/heads/ref-name'
+        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+        # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # For Generate-DockerImageVariants: Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
@@ -465,14 +457,13 @@ jobs:
         # echo "::set-output name=REF::$REF"
         # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
         # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-
-        # For Generate-DockerImageVariants: Set step output(s)
         echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
         echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
         echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
         echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
 
     - name: Login to docker registry
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
       run: echo "${DOCKERHUB_REGISTRY_PASSWORD}" | docker login -u "${DOCKERHUB_REGISTRY_USER}" --password-stdin
       env:
         DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
@@ -509,9 +500,7 @@ jobs:
 
     - name: Build and push (release)
       id: docker_build_release
-      # For Generate-DockerImageVariants: For CalVer releases. Each push to 'release' branch is a time-based release.
-      # if: startsWith(github.ref, 'refs/tags/')
-      if: github.ref == 'refs/heads/release'
+      if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
@@ -535,7 +524,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VARIANT_TAG: 3.10-curl-git-jq-ssh
-      # VARIANT_TAG_WITH_REF: 3.10-curl-git-jq-ssh-${GITHUB_REF}
       VARIANT_BUILD_DIR: variants/3.10-curl-git-jq-ssh
     steps:
     - name: Checkout
@@ -581,11 +569,12 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get 'ref-name' from 'refs/heads/ref-name'
+        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+        # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # For Generate-DockerImageVariants: Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
@@ -595,14 +584,13 @@ jobs:
         # echo "::set-output name=REF::$REF"
         # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
         # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-
-        # For Generate-DockerImageVariants: Set step output(s)
         echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
         echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
         echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
         echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
 
     - name: Login to docker registry
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
       run: echo "${DOCKERHUB_REGISTRY_PASSWORD}" | docker login -u "${DOCKERHUB_REGISTRY_USER}" --password-stdin
       env:
         DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
@@ -639,9 +627,7 @@ jobs:
 
     - name: Build and push (release)
       id: docker_build_release
-      # For Generate-DockerImageVariants: For CalVer releases. Each push to 'release' branch is a time-based release.
-      # if: startsWith(github.ref, 'refs/tags/')
-      if: github.ref == 'refs/heads/release'
+      if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
@@ -665,7 +651,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VARIANT_TAG: 3.10-curl-mysqlclient-openssl
-      # VARIANT_TAG_WITH_REF: 3.10-curl-mysqlclient-openssl-${GITHUB_REF}
       VARIANT_BUILD_DIR: variants/3.10-curl-mysqlclient-openssl
     steps:
     - name: Checkout
@@ -711,11 +696,12 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get 'ref-name' from 'refs/heads/ref-name'
+        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+        # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # For Generate-DockerImageVariants: Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
@@ -725,14 +711,13 @@ jobs:
         # echo "::set-output name=REF::$REF"
         # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
         # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-
-        # For Generate-DockerImageVariants: Set step output(s)
         echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
         echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
         echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
         echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
 
     - name: Login to docker registry
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
       run: echo "${DOCKERHUB_REGISTRY_PASSWORD}" | docker login -u "${DOCKERHUB_REGISTRY_USER}" --password-stdin
       env:
         DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
@@ -769,9 +754,7 @@ jobs:
 
     - name: Build and push (release)
       id: docker_build_release
-      # For Generate-DockerImageVariants: For CalVer releases. Each push to 'release' branch is a time-based release.
-      # if: startsWith(github.ref, 'refs/tags/')
-      if: github.ref == 'refs/heads/release'
+      if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
@@ -795,7 +778,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VARIANT_TAG: 3.9-curl-git-jq-ssh
-      # VARIANT_TAG_WITH_REF: 3.9-curl-git-jq-ssh-${GITHUB_REF}
       VARIANT_BUILD_DIR: variants/3.9-curl-git-jq-ssh
     steps:
     - name: Checkout
@@ -841,11 +823,12 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get 'ref-name' from 'refs/heads/ref-name'
+        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+        # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # For Generate-DockerImageVariants: Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
@@ -855,14 +838,13 @@ jobs:
         # echo "::set-output name=REF::$REF"
         # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
         # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-
-        # For Generate-DockerImageVariants: Set step output(s)
         echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
         echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
         echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
         echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
 
     - name: Login to docker registry
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
       run: echo "${DOCKERHUB_REGISTRY_PASSWORD}" | docker login -u "${DOCKERHUB_REGISTRY_USER}" --password-stdin
       env:
         DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
@@ -899,9 +881,7 @@ jobs:
 
     - name: Build and push (release)
       id: docker_build_release
-      # For Generate-DockerImageVariants: For CalVer releases. Each push to 'release' branch is a time-based release.
-      # if: startsWith(github.ref, 'refs/tags/')
-      if: github.ref == 'refs/heads/release'
+      if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
@@ -925,7 +905,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VARIANT_TAG: 3.9-curl-mysqlclient-openssl
-      # VARIANT_TAG_WITH_REF: 3.9-curl-mysqlclient-openssl-${GITHUB_REF}
       VARIANT_BUILD_DIR: variants/3.9-curl-mysqlclient-openssl
     steps:
     - name: Checkout
@@ -971,11 +950,12 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get 'ref-name' from 'refs/heads/ref-name'
+        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+        # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # For Generate-DockerImageVariants: Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
@@ -985,14 +965,13 @@ jobs:
         # echo "::set-output name=REF::$REF"
         # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
         # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-
-        # For Generate-DockerImageVariants: Set step output(s)
         echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
         echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
         echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
         echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
 
     - name: Login to docker registry
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
       run: echo "${DOCKERHUB_REGISTRY_PASSWORD}" | docker login -u "${DOCKERHUB_REGISTRY_USER}" --password-stdin
       env:
         DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
@@ -1029,9 +1008,7 @@ jobs:
 
     - name: Build and push (release)
       id: docker_build_release
-      # For Generate-DockerImageVariants: For CalVer releases. Each push to 'release' branch is a time-based release.
-      # if: startsWith(github.ref, 'refs/tags/')
-      if: github.ref == 'refs/heads/release'
+      if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
@@ -1055,7 +1032,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VARIANT_TAG: 3.8-curl-git-jq-ssh
-      # VARIANT_TAG_WITH_REF: 3.8-curl-git-jq-ssh-${GITHUB_REF}
       VARIANT_BUILD_DIR: variants/3.8-curl-git-jq-ssh
     steps:
     - name: Checkout
@@ -1101,11 +1077,12 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get 'ref-name' from 'refs/heads/ref-name'
+        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+        # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # For Generate-DockerImageVariants: Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
@@ -1115,14 +1092,13 @@ jobs:
         # echo "::set-output name=REF::$REF"
         # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
         # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-
-        # For Generate-DockerImageVariants: Set step output(s)
         echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
         echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
         echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
         echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
 
     - name: Login to docker registry
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
       run: echo "${DOCKERHUB_REGISTRY_PASSWORD}" | docker login -u "${DOCKERHUB_REGISTRY_USER}" --password-stdin
       env:
         DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
@@ -1159,9 +1135,7 @@ jobs:
 
     - name: Build and push (release)
       id: docker_build_release
-      # For Generate-DockerImageVariants: For CalVer releases. Each push to 'release' branch is a time-based release.
-      # if: startsWith(github.ref, 'refs/tags/')
-      if: github.ref == 'refs/heads/release'
+      if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
@@ -1185,7 +1159,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VARIANT_TAG: 3.8-curl-mysqlclient-openssl
-      # VARIANT_TAG_WITH_REF: 3.8-curl-mysqlclient-openssl-${GITHUB_REF}
       VARIANT_BUILD_DIR: variants/3.8-curl-mysqlclient-openssl
     steps:
     - name: Checkout
@@ -1231,11 +1204,12 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get 'ref-name' from 'refs/heads/ref-name'
+        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+        # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # For Generate-DockerImageVariants: Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
@@ -1245,14 +1219,13 @@ jobs:
         # echo "::set-output name=REF::$REF"
         # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
         # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-
-        # For Generate-DockerImageVariants: Set step output(s)
         echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
         echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
         echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
         echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
 
     - name: Login to docker registry
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
       run: echo "${DOCKERHUB_REGISTRY_PASSWORD}" | docker login -u "${DOCKERHUB_REGISTRY_USER}" --password-stdin
       env:
         DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
@@ -1289,9 +1262,7 @@ jobs:
 
     - name: Build and push (release)
       id: docker_build_release
-      # For Generate-DockerImageVariants: For CalVer releases. Each push to 'release' branch is a time-based release.
-      # if: startsWith(github.ref, 'refs/tags/')
-      if: github.ref == 'refs/heads/release'
+      if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
@@ -1311,91 +1282,38 @@ jobs:
       run: docker logout
       if: always()
 
-  # For Generate-DockerImageVariants: For CalVer releases. Each push to 'release' branch is a time-based release.
-  converge-master-and-release-branches:
-    needs: [build-3-12-curl-git-jq-ssh, build-3-12-curl-mysqlclient-openssl, build-3-11-curl-git-jq-ssh, build-3-11-curl-mysqlclient-openssl, build-3-10-curl-git-jq-ssh, build-3-10-curl-mysqlclient-openssl, build-3-9-curl-git-jq-ssh, build-3-9-curl-mysqlclient-openssl, build-3-8-curl-git-jq-ssh, build-3-8-curl-mysqlclient-openssl]
-    if: github.ref == 'refs/heads/release'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Merge release into master (fast-forward)
-        run: |
-          git checkout master
-          git merge release
-          git push origin master
-
-  # For Generate-DockerImageVariants: For CalVer releases. Each push to 'release' branch is a time-based release.
-  resolve-release-tag:
-    runs-on: ubuntu-latest
-    outputs:
-      TAG: ${{ steps.resolve-release-tag.outputs.TAG }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Resolve release tag
-        id: resolve-release-tag
-        run: |
-          set +e
-          # E.g. 20210402
-          TODAYS_DATE=$( date -u '+%Y%m%d' )
-          # Is this the first tag for this date?
-          TODAYS_DATE_TAGS=$( git tag --list | grep "^$TODAYS_DATE" )
-          TAG=
-          if [ -z "$TODAYS_DATE_TAGS" ]; then
-              # E.g. 20210402.0.0
-              TAG="$TODAYS_DATE.0.0" # Send this to stdout
-          else
-              # E.g. if there are 20210402.0.0, 20210402.0.1, 20210402.0.2, this returns 2
-              VERSION_MINOR_LATEST=$( echo "$TODAYS_DATE_TAGS" | cut -d '.' -f 3 | sort -nr | head -n1 )
-              # Minor version
-              VERSION_MINOR=$( expr "$VERSION_MINOR_LATEST" + 1 )
-              # E.g. 20210402.0.3
-              TAG="$TODAYS_DATE.0.$VERSION_MINOR"  # Send this to stdout
-          fi
-          echo "TODAYS_DATE: $TODAYS_DATE"
-          echo "TODAYS_DATE_TAGS: $TODAYS_DATE_TAGS"
-          echo "TAG: $TAG"
-          echo "::set-output name=TAG::$TAG"
-      - name: Print outputs
-        run: echo ${{ steps.resolve-release-tag.outputs.TAG }}
-
   update-draft-release:
-    needs: [build-3-12-curl-git-jq-ssh, build-3-12-curl-mysqlclient-openssl, build-3-11-curl-git-jq-ssh, build-3-11-curl-mysqlclient-openssl, build-3-10-curl-git-jq-ssh, build-3-10-curl-mysqlclient-openssl, build-3-9-curl-git-jq-ssh, build-3-9-curl-mysqlclient-openssl, build-3-8-curl-git-jq-ssh, build-3-8-curl-mysqlclient-openssl, resolve-release-tag]
+    needs: [build-3-12-curl-git-jq-ssh, build-3-12-curl-mysqlclient-openssl, build-3-11-curl-git-jq-ssh, build-3-11-curl-mysqlclient-openssl, build-3-10-curl-git-jq-ssh, build-3-10-curl-mysqlclient-openssl, build-3-9-curl-git-jq-ssh, build-3-9-curl-mysqlclient-openssl, build-3-8-curl-git-jq-ssh, build-3-8-curl-mysqlclient-openssl]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Print inputs
-        run: echo ${{ needs.resolve-release-tag.outputs.TAG }}
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5
         with:
           config-name: release-drafter.yml
           publish: false
-          name: ${{ needs.resolve-release-tag.outputs.TAG }}
-          tag: ${{ needs.resolve-release-tag.outputs.TAG }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-draft-release:
-    needs: [build-3-12-curl-git-jq-ssh, build-3-12-curl-mysqlclient-openssl, build-3-11-curl-git-jq-ssh, build-3-11-curl-mysqlclient-openssl, build-3-10-curl-git-jq-ssh, build-3-10-curl-mysqlclient-openssl, build-3-9-curl-git-jq-ssh, build-3-9-curl-mysqlclient-openssl, build-3-8-curl-git-jq-ssh, build-3-8-curl-mysqlclient-openssl, converge-master-and-release-branches, resolve-release-tag]
-    # For Generate-DockerImageVariants: For CalVer releases. Each push to 'release' branch is a time-based release.
-    # if: startsWith(github.ref, 'refs/tags/')
-    if: github.ref == 'refs/heads/release'
+    needs: [build-3-12-curl-git-jq-ssh, build-3-12-curl-mysqlclient-openssl, build-3-11-curl-git-jq-ssh, build-3-11-curl-mysqlclient-openssl, build-3-10-curl-git-jq-ssh, build-3-10-curl-mysqlclient-openssl, build-3-9-curl-git-jq-ssh, build-3-9-curl-mysqlclient-openssl, build-3-8-curl-git-jq-ssh, build-3-8-curl-mysqlclient-openssl]
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Resolve tag
+        id: resolve-tag
+        run: |
+          # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+          REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+          echo "::set-output name=REF::$REF"
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5
         with:
           config-name: release-drafter.yml
           publish: true
-          name: ${{ needs.resolve-release-tag.outputs.TAG }}
-          tag: ${{ needs.resolve-release-tag.outputs.TAG }}
+          name: ${{ steps.resolve-tag.outputs.REF }}
+          tag: ${{ steps.resolve-tag.outputs.REF }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/generate/templates/.github/release-drafter.yml.ps1
+++ b/generate/templates/.github/release-drafter.yml.ps1
@@ -1,5 +1,4 @@
 @'
-# For Generate-DockerImageVariants: For CalVer releases. Each push to 'release' branch is a time-based release.
 name-template: '$RESOLVED_VERSION  🌈'
 tag-template: '$RESOLVED_VERSION'
 categories:


### PR DESCRIPTION
Previously, there was a reliance on `release` branch for releases.

Now, only the master, pr, and tag refs are used for the ci pipeline. Benefits:
- Ubiquitous, easy to understand
- Generic ci means reusable ci configs for other projects

Closes #10

## TODO
- [ ] Squash commits
- [ ] Update commit message